### PR TITLE
Bump the node version for CI from 10.9 to 10.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
     working_directory: ~/mern-starter # directory where steps will run
     docker: # run the steps with Docker
-      - image: circleci/node:10.9
+      - image: circleci/node:10.13
       - image: mongo:3.6.7-stretch
     steps: # a collection of executable commands 
       - checkout # special step to check out source code to working directory


### PR DESCRIPTION
Updates the config file for circleCI to use node v10.13  instead of 10.9