### PR TITLE
Split out dev and master deployments

### DIFF
--- a/.github/workflows/deploy_beta.yml
+++ b/.github/workflows/deploy_beta.yml
@@ -1,0 +1,28 @@
+name: Deploy MYR
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  update_upstream:
+    runs-on: ubuntu-latest
+    container:
+      image: docker
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set the branch variable
+        uses: nelonoel/branch-name@v1.0.1
+      - name: Log into Quay
+        run: docker login quay.io -u umlecg+myr_bot -p ${{ secrets.QUAY_BOT_PASSWORD }}
+      - name: Build the docker image
+        run: docker build -t quay.io/umlecg/myr-backend:${BRANCH_NAME} .
+      - name: Push the new image
+        run: docker push quay.io/umlecg/myr-backend:${BRANCH_NAME}
+      - name: Notify the build repository
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.MYR_ACCESS_TOKEN }}
+          event-type: update_dev
+          repository: engaging-computing/MYR-build

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -1,10 +1,9 @@
-name: Deploy MYR
+name: Deploy production MYR
 
 on:
   push:
     branches:
       - master
-      - dev
 
 jobs:
   update_upstream:
@@ -25,5 +24,5 @@ jobs:
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.MYR_ACCESS_TOKEN }}
-          event-type: update_${BRANCH_NAME}
+          event-type: update_master
           repository: engaging-computing/MYR-build


### PR DESCRIPTION
Deployments to staging and production now use different files since repository dispatch action does not allow for enviornment variables